### PR TITLE
Ci test only (re-order operations)

### DIFF
--- a/litex_hw_ci.py
+++ b/litex_hw_ci.py
@@ -267,8 +267,11 @@ def run_config_tests(name, config, report, steps, report_filename, test_start_ti
     start_time = time.time()
     for step in steps:
         # When --test-only, skip compilation steps.
-        if test_only and (step in ["firmware_build", "gateware_build", "software_build"]):
+        if test_only and (step in ["firmware_build", "gateware_build"]):
             status = LiteXCIStatus.NOT_RUN
+        elif test_only and (step in ["software_build"]):
+            config.software_command += " --prepare-only"
+            status = getattr(config, step)()
         else:
             status = getattr(config, step)()
         report[name][step.capitalize()] = enum_to_str(status)


### PR DESCRIPTION
To be able to **test only** (ie no gateware, nor software build and only copy assets and running test sequence), it's required to:
- when not **test only** mode copying binaries to build directory after build and before preparing tftp
- when preparing tftp directory instead of *linux/images* files,  we use *build_xxx/images* files
- when **test only** mode: software build step must be limited to the copy *build_xxx/images/xx* files to tftp

Note: `litex_hw_ci.py` by default skip `software_build` step in **test only** mode. Instead a new argument is added to the command to specify all steps must be skipped by `make.py` to only copy assets. (Maybe splitting build and copy make sense).